### PR TITLE
Explicitly parse the config as json

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,7 +207,7 @@ focalboard_config_enablePublicSharedBoards: false  # noqa var-naming
 #
 # For a more advanced customization, you can extend the default (see `focalboard_configuration_extension_json`)
 # or completely replace this variable with your own template.
-focalboard_configuration_default: "{{ lookup('template', 'templates/config.json.j2') }}"
+focalboard_configuration_default: "{{ lookup('template', 'templates/config.json.j2') | from_json }}"
 
 # Your custom JSON configuration for Element should go to `focalboard_configuration_extension_json`.
 # This configuration extends the default starting configuration (`focalboard_configuration_default`).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -207,9 +207,6 @@ focalboard_config_enablePublicSharedBoards: false  # noqa var-naming
 #
 # For a more advanced customization, you can extend the default (see `focalboard_configuration_extension_json`)
 # or completely replace this variable with your own template.
-#
-# The side-effect of this lookup is that Ansible would even parse the JSON for us, returning a dict.
-# This is unlike what it does when looking up YAML template files (no automatic parsing there).
 focalboard_configuration_default: "{{ lookup('template', 'templates/config.json.j2') }}"
 
 # Your custom JSON configuration for Element should go to `focalboard_configuration_extension_json`.


### PR DESCRIPTION
I know the comment said that ansible does the parsing automatically. But today, for me it did not, so I added explicit parsing and removed the comment.