### PR TITLE
Move license attribution out of config.json.j2

### DIFF
--- a/templates/config.json.j2
+++ b/templates/config.json.j2
@@ -1,9 +1,3 @@
-{#
-SPDX-FileCopyrightText: 2023 Slavi Pantaleev
-
-SPDX-License-Identifier: AGPL-3.0-or-later
-#}
-
 {
 	"serverRoot": {{ focalboard_config_serverRoot | to_json }},
 	"port": {{ focalboard_config_port }},

--- a/templates/config.json.j2.license
+++ b/templates/config.json.j2.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Slavi Pantaleev
+
+SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
For https://github.com/mother-of-all-self-hosting/ansible-role-focalboard/pull/8.